### PR TITLE
Bump deps and misc small code improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ cdk.out
 .template.cdk.context.json
 .*.log
 *.bak
+
+# NodeJS
+node_modules/

--- a/cdk_stacks/alb.py
+++ b/cdk_stacks/alb.py
@@ -15,7 +15,7 @@ from constructs import Construct
 
 class ApplicationLoadBalancerStack(Stack):
 
-  def __init__(self, scope: Construct, construct_id: str, vpc, **kwargs) -> None:
+  def __init__(self, scope: Construct, construct_id: str, vpc: aws_ec2.IVpc, **kwargs) -> None:
 
     super().__init__(scope, construct_id, **kwargs)
 

--- a/cdk_stacks/aurora_postgresql.py
+++ b/cdk_stacks/aurora_postgresql.py
@@ -19,7 +19,7 @@ from constructs import Construct
 
 class AuroraPostgresqlStack(Stack):
 
-  def __init__(self, scope: Construct, construct_id: str, vpc, **kwargs) -> None:
+  def __init__(self, scope: Construct, construct_id: str, vpc: aws_ec2.IVpc, **kwargs) -> None:
     super().__init__(scope, construct_id, **kwargs)
 
     db_cluster_name = self.node.try_get_context('db_cluster_name') or 'langfuse-db'

--- a/cdk_stacks/ecs_alb_fargate_service.py
+++ b/cdk_stacks/ecs_alb_fargate_service.py
@@ -7,7 +7,9 @@ import aws_cdk as cdk
 from aws_cdk import (
   Stack,
   aws_ec2,
+  aws_ecs,
   aws_ecs_patterns,
+  aws_elasticloadbalancingv2 as elbv2,
 )
 
 from constructs import Construct
@@ -15,9 +17,17 @@ from constructs import Construct
 
 class ECSAlbFargateServiceStack(Stack):
 
-  def __init__(self, scope: Construct, construct_id: str,
-    vpc, ecs_cluster, ecs_task_definition,
-    load_balancer, sg_rds_client, **kwargs) -> None:
+  def __init__(
+    self,
+    scope: Construct,
+    construct_id: str,
+    vpc: aws_ec2.IVpc,
+    ecs_cluster: aws_ecs.ICluster,
+    ecs_task_definition: aws_ecs.ITaskDefinition,
+    load_balancer: elbv2.IApplicationLoadBalancer,
+    sg_rds_client: aws_ec2.ISecurityGroup,
+    **kwargs,
+  ) -> None:
 
     super().__init__(scope, construct_id, **kwargs)
 

--- a/cdk_stacks/ecs_cluster.py
+++ b/cdk_stacks/ecs_cluster.py
@@ -6,6 +6,7 @@ import aws_cdk as cdk
 
 from aws_cdk import (
   Stack,
+  aws_ec2 as ec2,
   aws_ecs as ecs,
 )
 
@@ -14,7 +15,7 @@ from constructs import Construct
 
 class ECSClusterStack(Stack):
 
-  def __init__(self, scope: Construct, construct_id: str, vpc, **kwargs) -> None:
+  def __init__(self, scope: Construct, construct_id: str, vpc: ec2.IVpc, **kwargs) -> None:
 
     super().__init__(scope, construct_id, **kwargs)
 

--- a/cdk_stacks/ecs_task.py
+++ b/cdk_stacks/ecs_task.py
@@ -6,8 +6,10 @@ import aws_cdk as cdk
 
 from aws_cdk import (
   Stack,
+  aws_ecr,
   aws_ecs,
-  aws_iam
+  aws_iam,
+  aws_secretsmanager,
 )
 
 from constructs import Construct
@@ -21,7 +23,15 @@ def check_env_variables(envars: dict, vars: List[str]):
 
 class ECSTaskStack(Stack):
 
-  def __init__(self, scope: Construct, construct_id: str, ecr_repository, database_secret, load_balancer_url, **kwargs) -> None:
+  def __init__(
+    self,
+    scope: Construct,
+    construct_id: str,
+    ecr_repository: aws_ecr.Repository,
+    database_secret: aws_secretsmanager.ISecret,
+    load_balancer_url: str,
+    **kwargs,
+  ) -> None:
 
     super().__init__(scope, construct_id, **kwargs)
 

--- a/examples/tracing_for_langchain_bedrock.ipynb
+++ b/examples/tracing_for_langchain_bedrock.ipynb
@@ -5,9 +5,11 @@
    "id": "fa62892f-5737-428d-a192-c53b07f0923c",
    "metadata": {},
    "source": [
-    "# Tracaing for LangChain (Python)\n",
+    "# Tracing for LangChain (Python)\n",
     "\n",
-    "This notebook works well with the `Data Science 2.0 kernel` on a SageMaker Studio `ml.t3.medium` instance."
+    "> This notebook has been tested with the `Python 3` kernel in SageMaker AI Studio (SM Distribution v2.2.1)\n",
+    "\n",
+    "In this example notebook, we'll test recording traces to the deployed Langfuse environment from LangChain."
    ]
   },
   {
@@ -29,10 +31,7 @@
    "source": [
     "%%capture --no-stderr\n",
     "\n",
-    "!pip install -U langfuse==2.39.3\n",
-    "!pip install -U langchain==0.2.11\n",
-    "!pip install -U langchain-community==0.2.10\n",
-    "!pip install -U langchain-aws==0.1.12"
+    "%pip install -U langchain==0.2.17 langchain-aws langchain-community==0.2.19 langfuse==2.57.5"
    ]
   },
   {
@@ -47,12 +46,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "langchain==0.2.11\n",
-      "langchain-aws==0.1.12\n",
-      "langchain-community==0.2.10\n",
-      "langchain-core==0.2.24\n",
-      "langchain-text-splitters==0.2.2\n",
-      "langfuse==2.39.3\n"
+      "langchain==0.2.17\n",
+      "langchain-aws==0.1.18\n",
+      "langchain-community==0.2.19\n",
+      "langchain-core==0.2.43\n",
+      "langchain-text-splitters==0.2.4\n",
+      "langfuse==2.57.5\n"
      ]
     }
    ],
@@ -127,7 +126,7 @@
     "\n",
     "region = boto3.Session().region_name\n",
     "\n",
-    "model_kwargs={\n",
+    "model_kwargs = {\n",
     "    \"max_tokens\": 512,\n",
     "    \"temperature\": 0,\n",
     "    \"top_p\": 0.9\n",
@@ -826,9 +825,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 3.0)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:123456012:image/sagemaker-data-science-310-v1"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -840,7 +839,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.172.0
+aws-cdk-lib==2.175.1
 constructs>=10.0.0,<11.0.0
-cdk-ecr-deployment==3.0.82
+cdk-ecr-deployment==3.0.154


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Just some minor version bumps and small code tweaks to help keep the sample up-to-date and readable:

1. Upgrade `aws-cdk-lib` to latest and `cdk-ecr-deployment` to most recent working version not affected by the bug mentioned [here](https://github.com/cdklabs/cdk-ecr-deployment/issues/1017#issuecomment-2586993243)
2. Bump LangChain and LangFuse versions in the example notebook (but not consuming LangChain v0.3 yet, because SageMaker Studio's installed Jupyter AI extension is still wanting v0.2 and I thought that was a dangerous dep to break)
    - Consolidate the `pip install` commands in the notebook to one, for more reliable dependency resolution; and prefer `%pip` magic (which should [always resolve to the package manager within the current notebook kernel](https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-pip)) rather than `!pip` (which, in rare/weird environments, can possibly refer to something else)
    - Also update the note about SMStudio kernel version
4. gitignore `node_modules` for the benefit of anybody (like me) who prefers to install their AWS CDK CLI locally per-project rather than globally - in case of version mismatches
5. Add explicit type annotations to the parameters of the various CDK `Stack` objects, so IDE auto-complete works within these files.

**Testing done:**

Deployed the stacks with updated CDK version and code in a new environment; opened the example notebook in a SageMaker AI Studio JupyterLab space (SM Distribution v2.2.1); ran through and verified tracing worked and was visible in the Langfuse environment.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
