### PR TITLE
Enable S3 batch export for Langfuse traces

### DIFF
--- a/langfuse-v3/cdk_stacks/ecs_task_langfuse_web.py
+++ b/langfuse-v3/cdk_stacks/ecs_task_langfuse_web.py
@@ -104,6 +104,12 @@ class ECSTaskLangfuseWebStack(Stack):
       # "LANGFUSE_S3_MEDIA_UPLOAD_PREFIX": "media/", # default: "" (the bucket root)
       "LANGFUSE_S3_MEDIA_UPLOAD_ENABLED": "true",
 
+      # Batch Export Configuration
+      "LANGFUSE_S3_BATCH_EXPORT_ENABLED": "true",
+      "LANGFUSE_S3_BATCH_EXPORT_BUCKET": s3_event_bucket.bucket_name,
+      "LANGFUSE_S3_BATCH_EXPORT_PREFIX": "exports/",
+      "LANGFUSE_S3_BATCH_EXPORT_REGION": self.region,
+
       "NEXTAUTH_URL": load_balancer_url,
     }
 
@@ -129,3 +135,7 @@ class ECSTaskLangfuseWebStack(Stack):
     cdk.CfnOutput(self, 'TaskDefinitionArn',
       value=self.ecs_task_definition.task_definition_arn,
       export_name=f'{self.stack_name}-TaskDefinitionArn')
+
+
+
+

--- a/langfuse-v3/cdk_stacks/ecs_task_langfuse_worker.py
+++ b/langfuse-v3/cdk_stacks/ecs_task_langfuse_worker.py
@@ -102,6 +102,12 @@ class ECSTaskLangfuseWorkerStack(Stack):
       "LANGFUSE_S3_MEDIA_UPLOAD_BUCKET": s3_blob_bucket.bucket_name,
       # "LANGFUSE_S3_MEDIA_UPLOAD_PREFIX": "media/", # default: "" (the bucket root)
       "LANGFUSE_S3_MEDIA_UPLOAD_ENABLED": "true",
+
+      # Batch Export Configuration
+      "LANGFUSE_S3_BATCH_EXPORT_ENABLED": "true",
+      "LANGFUSE_S3_BATCH_EXPORT_BUCKET": s3_event_bucket.bucket_name,
+      "LANGFUSE_S3_BATCH_EXPORT_PREFIX": "exports/",
+      "LANGFUSE_S3_BATCH_EXPORT_REGION": self.region,
     }
 
     repository = ecr_repositories['langfuse-worker']
@@ -127,3 +133,7 @@ class ECSTaskLangfuseWorkerStack(Stack):
     cdk.CfnOutput(self, 'TaskDefinitionArn',
       value=self.ecs_task_definition.task_definition_arn,
       export_name=f'{self.stack_name}-TaskDefinitionArn')
+
+
+
+


### PR DESCRIPTION
*Issue #23 , if available:*

*Description of changes:*
## Summary

  - Added S3 batch export configuration to enable manual data exports through the UI
  - Allows users to export selected traces and observations to S3 on-demand

## Changes

  - Added LANGFUSE_S3_BATCH_EXPORT_* environment variables to both web and worker tasks
  - Exports are triggered manually through the Langfuse UI
  - Exported files will be stored in the event bucket under exports/ prefix


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
