### PR TITLE
fix: Update Aurora PostgreSQL version from 15.4 to 15.8 for regional compatibility

### DIFF
--- a/langfuse-v3/cdk_stacks/aurora_postgresql.py
+++ b/langfuse-v3/cdk_stacks/aurora_postgresql.py
@@ -65,7 +65,7 @@ class AuroraPostgresqlStack(Stack):
     )
     rds_credentials = aws_rds.Credentials.from_secret(db_secret)
 
-    rds_engine = aws_rds.DatabaseClusterEngine.aurora_postgres(version=aws_rds.AuroraPostgresEngineVersion.VER_15_4)
+    rds_engine = aws_rds.DatabaseClusterEngine.aurora_postgres(version=aws_rds.AuroraPostgresEngineVersion.VER_15_8)
 
     #XXX: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.ParameterGroups.html#AuroraPostgreSQL.Reference.Parameters.Cluster
     rds_cluster_param_group = aws_rds.ParameterGroup(self, 'AuroraPostgreSQLClusterParamGroup',


### PR DESCRIPTION
## Issue
Aurora PostgreSQL version 15.4 is not available in all AWS regions, causing deployment failures.

## Error
```
Cannot find version 15.4 for aurora-postgresql (Service: Rds, Status Code: 400)
```

## Changes
- Updated Aurora PostgreSQL version from 15.4 to 15.8 in `langfuse-v3/cdk_stacks/aurora_postgresql.py`

We can check available versions by the following command:

```
aws rds describe-db-engine-versions \
  --engine aurora-postgresql \
  --query 'DBEngineVersions[].EngineVersion' \
  --region us-east-1
  ```

## Rationale
- Version 15.8 is stable and available across all AWS regions
- Minor version upgrade within same major version (no breaking changes expected)
- Tested successfully in us-east-1

## Testing
Deployed successfully in us-east-1 with version 15.8.